### PR TITLE
bug 26, 27 & 28 fixes

### DIFF
--- a/views/default/resources/hybridauth/authenticate.php
+++ b/views/default/resources/hybridauth/authenticate.php
@@ -55,7 +55,12 @@ if (!$profile) {
 	return;
 }
 
-$elgg_forward_url = get_input('elgg_forward_url', $_SESSION['last_forward_from']);
+$session_forward_url = null;
+if (($session = elgg_get_session()) && $session->has('last_forward_from')) {
+	$session_forward_url = $session->get('last_forward_from');
+}
+
+$elgg_forward_url = get_input('elgg_forward_url', $session_forward_url);
 if ($elgg_forward_url) {
 	$forward_url = urldecode($elgg_forward_url);
 } else {
@@ -63,8 +68,8 @@ if ($elgg_forward_url) {
 	if ($user) {
 		$forward_url = "settings/user/{$user->username}?{$query}";
 	} else {
-		$forward_url = "?{$query}";
-	}
+		$forward_url = "?{$query}"; 
+        }
 }
 
 if ($session_handle && $session_handle != \Elgg\HybridAuth\Session::DEFAULT_HANDLE) {
@@ -135,8 +140,34 @@ if ($users) {
 	// Profile for this provider exists
 	if (!elgg_is_logged_in()) {
 		$user_to_login->elgg_hybridauth_login = 1;
-		login($user_to_login);
-		system_message(elgg_echo('hybridauth:login:provider', array($provider->getName())));
+                try {
+                        login($user_to_login);
+                } catch(LoginException $e){
+                        register_error($e->getMessage());
+                        forward(REFERER);
+                }
+                             
+                $user = $user_to_login;
+                $forward_source = null;
+                
+                //code extracted from login action:
+                
+                // elgg_echo() caches the language and does not provide a way to change the language.
+                // @todo we need to use the config object to store this so that the current language
+                // can be changed. Refs #4171
+                if ($user->language) {
+                        $message = elgg_echo('hybridauth:login:provider', array($provider->getName()), $user->language);
+                } else {
+                        $message = elgg_echo('hybridauth:login:provider', array($provider->getName()));
+                }
+
+                // clear after login in case login fails
+                if ($session) $session->remove('last_forward_from');
+
+                $params = array('user' => $user, 'source' => $forward_source);
+                $forward_url = elgg_trigger_plugin_hook('login:forward', 'user', $params, $forward_url);
+                
+		system_message($message);
 		forward($forward_url);
 	}
 }
@@ -171,7 +202,7 @@ if ($email && $users = get_user_by_email($email)) {
 	}
 
 	$title = elgg_echo('hybridauth:register');
-	$content = elgg_view_form('hybridauth/register', array(), array(
+	$content = elgg_view_form('hybridauth/register', array('class' => 'elgg-form-register'), array(
 		'provider' => $provider->getName(),
 		'profile' => $profile,
 		'invitecode' => $_SESSION['hybridauth']['invitecode'],


### PR DESCRIPTION
- get 'last_forward_from' session value through elgg_get_session() API
- Encapsulate login call in a try/catch block to manage LoginExceptions: "not yet validated by admin" and "banned" users
- Trigger 'login:forward','user' hook if login is successfull
- Add missing 'elgg-form-register' class in 'hybridauth/register' view