### PR TITLE
Static file for credentials proposed feature - issue #34

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ robots.txt
 composer.lock
 Gemfile.lock
 .env
+/settings.php
+

--- a/languages/fr.php
+++ b/languages/fr.php
@@ -53,8 +53,8 @@ return array(
 	'hybridauth:persistent_session:disable' => "Désactivé",
 
 	'hybridauth:provider:enable' => "Activer ce fournisseur d'identité",
-	'hybridauth:provider:enabled' => "Activer",
-	'hybridauth:provider:disabled' => "Désactiver",
+	'hybridauth:provider:enabled' => "Activé",
+	'hybridauth:provider:disabled' => "Désactivé",
 
 	'hybridauth:provider:id' => "ID du fournisseur",
 	'hybridauth:provider:key' => "Clef publique",
@@ -125,8 +125,8 @@ return array(
 	'hybridauth:accounts' => "Comptes sociaux connectés",
 
 	'hybridauth:public_auth' => "Activer la connexion et l'inscription avec les fournisseurs sociaux (étendre les formulaires) pour les utilisateurs non connectés",
-	'hybridauth:public_auth:disable' => "Désactiver",
-	'hybridauth:public_auth:enable' => "Activer",
+	'hybridauth:public_auth:disable' => "Désactivé",
+	'hybridauth:public_auth:enable' => "Activé",
 
 	'hybridauth:provider:openid:name' => "Fournisseur OpenID",
 	'hybridauth:provider:openid:name:help' => "Nom du fournisseur OpenID (par ex. StackExchange)",

--- a/settings_dist.php
+++ b/settings_dist.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * elgg_hybridauth settings template file
+ * Copy and save as settings.php in same folder (settings.php file is ignored by git)
+ * Provided API keys and credentials will override plugin config
+ * 
+ * Usage : 
+ *  - any non-empty key/id/secret defined here will be used instead of plugin settings
+ *  - if set to FALSE, the plugin setting value is ignored (ie. cannot use this provider)
+ */
+
+
+
+$static_settings = array();
+
+// OpenID - no key/secret required
+
+// Yahoo
+$static_settings['providers']['Yahoo']['keys']['key'] = '';
+$static_settings['providers']['Yahoo']['keys']['secret'] = '';
+
+// AOL - no key/secret required
+
+// Google
+$static_settings['providers']['Google']['keys']['id'] = '';
+$static_settings['providers']['Google']['keys']['secret'] = '';
+
+// Facebook
+$static_settings['providers']['Facebook']['keys']['id'] = '';
+$static_settings['providers']['Facebook']['keys']['secret'] = '';
+
+// Instagram
+$static_settings['providers']['Instagram']['keys']['id'] = '';
+$static_settings['providers']['Instagram']['keys']['secret'] = '';
+
+// Twitter
+$static_settings['providers']['Twitter']['keys']['key'] = '';
+$static_settings['providers']['Twitter']['keys']['secret'] = '';
+
+// Live
+$static_settings['providers']['Live']['keys']['id'] = '';
+$static_settings['providers']['Live']['keys']['secret'] = '';
+
+// LinkedIn
+$static_settings['providers']['LinkedIn']['keys']['key'] = '';
+$static_settings['providers']['LinkedIn']['keys']['secret'] = '';
+
+// Foursquare
+$static_settings['providers']['Foursquare']['keys']['id'] = '';
+$static_settings['providers']['Foursquare']['keys']['secret'] = '';
+
+
+
+

--- a/start.php
+++ b/start.php
@@ -133,6 +133,23 @@ function elgg_hybridauth_config($hook, $type, $return, $params) {
 		'debug_file' => elgg_get_config('dataroot') . 'elgg_hybridauth_debug',
 		'providers' => unserialize(elgg_get_plugin_setting('providers', 'elgg_hybridauth'))
 	);
+	
+	/* Use static file config if set
+	 * Sets providers key/id and secret if defined (overrides plugin settings)
+	 * Currently handles keys only, as other settings contain no sensitive information
+	 */
+	$settings_file = dirname(__FILE__).'/settings.php';
+	if (file_exists($settings_file)) {
+		include_once($settings_file);
+		foreach ($static_settings['providers'] as $provider => $settings) {
+			if (isset($settings['keys'])) {
+				foreach ($settings['keys'] as $key_name => $key_value) {
+					if (!empty($key_value)) { $defaults['providers'][$provider]['keys'][$key_name] = $key_value; }
+					if ($key_value === false) { unset($defaults['providers'][$provider]['keys'][$key_name]); }
+				}
+			}
+		}
+	}
 
 	$return = array_merge($defaults, $return);
 


### PR DESCRIPTION
Hi,

Here's a proposed static config file feature proposition following https://github.com/arckinteractive/elgg_hybridauth/issues/34#issuecomment-344689121 : in this version, only the credentials (keys, ids, secrets) can be set and used : 
 - any non-empty value defined in settings.php will override plugin setting
 - empty values and undefined entries are ignored (plugin setting is kept)
 - values set to false will remove the plugin setting value if it is set

=> I didn't found very useful to define the other plugin settings values, as they are non-sensitive data. But can do if it's worth it ?

I haven't changed the README file, but the settings_dist.php file is self-documented.
An proposed doc section could be : 
### Static file configuration ###
To avoid disclosing providers keys, IDs and secrets to site admins, you can use a static configuration file. This file should be named settings.php and is ignored by git.
The non-empty key/id/secret defined in this file will be used instead of plugin settings
If set to FALSE, the plugin setting value (from admin panel) will be ignored, ie. this makes the corresponding provider unusable.
* copy the settings_dist.php file to settings.php
* edit the file and add the wanted key, id and secret values, and save it